### PR TITLE
feat: Implement first two vertical slices for CRM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,121 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak
+venv.bak
+
+# Spyder project settings
+.spyderproject
+.spyderworkspace
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# VS Code
+.vscode/
+
+# SQLite databases
+*.db
+*.sqlite
+*.sqlite3
+
+# Temporary files
+*.swp
+*~
+*.tmp

--- a/gestion_comercial/sistema_comercial/agent/tools.py
+++ b/gestion_comercial/sistema_comercial/agent/tools.py
@@ -1,6 +1,6 @@
 from langchain_core.tools import tool
 import gestion_comercial.sistema_comercial.database as db
-from gestion_comercial.sistema_comercial.models.data_models import Customer
+from gestion_comercial.sistema_comercial.models.data_models import Customer, Lead
 import json
 
 @tool
@@ -57,3 +57,49 @@ def get_customer_details(customer_id: str) -> str:
     if customer:
         return json.dumps(customer.__dict__, default=str)
     return f"Error: No se encontró ningún cliente con el ID {customer_id}."
+
+# --- Lead/Opportunity Management Tools ---
+
+@tool
+def add_new_lead(customer_id: str, source: str, estimated_value: float = 0.0) -> str:
+    """
+    Creates a new lead/opportunity for a given customer.
+
+    Args:
+        customer_id: The ID of the existing customer.
+        source: Where the lead came from (e.g., 'website', 'referral').
+        estimated_value: The estimated monetary value of the potential sale.
+
+    Returns:
+        A confirmation message with the new lead's ID.
+    """
+    # First, check if the customer exists
+    if not db.get_customer_by_id(customer_id):
+        return f"Error: No se puede crear una oportunidad para un cliente que no existe. ID de cliente no encontrado: {customer_id}"
+
+    new_lead = Lead(
+        customer_id=customer_id,
+        source=source,
+        estimated_value=estimated_value
+    )
+    db.add_lead(new_lead)
+    return f"Éxito: Oportunidad creada para el cliente {customer_id} con el ID de oportunidad {new_lead.id}."
+
+@tool
+def update_lead_status_tool(lead_id: str, new_status: str, new_pipeline_stage: str) -> str:
+    """
+    Updates the status and pipeline stage of an existing lead.
+
+    Args:
+        lead_id: The ID of the lead to update.
+        new_status: The new status (e.g., 'contactado', 'calificado', 'cerrado ganado').
+        new_pipeline_stage: The new stage in the sales pipeline (e.g., 'negociacion', 'propuesta').
+
+    Returns:
+        A confirmation message.
+    """
+    success = db.update_lead_status(lead_id, new_status, new_pipeline_stage)
+    if success:
+        return f"Éxito: El estado de la oportunidad {lead_id} ha sido actualizado."
+    else:
+        return f"Error: No se pudo actualizar la oportunidad {lead_id}. Verifique que el ID es correcto."

--- a/gestion_comercial/sistema_comercial/agents/corps/capitanes/crm/capitan_oportunidades_y_pipeline.py
+++ b/gestion_comercial/sistema_comercial/agents/corps/capitanes/crm/capitan_oportunidades_y_pipeline.py
@@ -1,0 +1,22 @@
+import flet as ft
+from .oportunidades_y_pipeline.teniente import TenienteOportunidadesYPipeline
+
+class CapitanOportunidadesYPipeline:
+    def __init__(self, page: ft.Page):
+        self.page = page
+        self.teniente = TenienteOportunidadesYPipeline(page=self.page)
+        print("Capitán de Oportunidades y Pipeline: En servicio.")
+
+    def ejecutar_mision(self, mision: str) -> str:
+        """
+        Recibe una misión del general y la delega al teniente.
+        La 'mision' es una cadena que contiene la operación a realizar.
+        Ej: "command='add', customer_id='some-uuid', source='website'"
+        """
+        print(f"Capitán (Pipeline): Misión recibida - '{mision}'.")
+        print("Capitán: Delegando operación al equipo táctico.")
+
+        resultado_tactico = self.teniente.ejecutar_operacion(mision)
+
+        print("Capitán: Reporte táctico recibido.")
+        return f"Capitán: Misión completada. {resultado_tactico}"

--- a/gestion_comercial/sistema_comercial/agents/corps/capitanes/crm/oportunidades_y_pipeline/sargento.py
+++ b/gestion_comercial/sistema_comercial/agents/corps/capitanes/crm/oportunidades_y_pipeline/sargento.py
@@ -1,0 +1,23 @@
+import flet as ft
+from .soldado import SoldadoOportunidadesYPipeline
+
+class SargentoOportunidadesYPipeline:
+    def __init__(self, page: ft.Page):
+        self.page = page
+        self.soldado = SoldadoOportunidadesYPipeline(page=self.page)
+        print("Sargento de Oportunidades y Pipeline: Listo para la acción.")
+
+    def ejecutar_tarea(self, tarea: str) -> str:
+        """
+        Recibe una tarea del teniente y la convierte en una acción para el soldado.
+        """
+        print(f"Sargento (Pipeline): Tarea recibida - '{tarea}'.")
+
+        # La tarea es la acción directa para el soldado en este caso.
+        accion_soldado = tarea
+
+        print(f"Sargento: Dando orden final al soldado: '{accion_soldado}'")
+        resultado_soldado = self.soldado.ejecutar_accion(accion_soldado)
+
+        print("Sargento: Reporte del soldado recibido.")
+        return f"Sargento: Tarea completada. {resultado_soldado}"

--- a/gestion_comercial/sistema_comercial/agents/corps/capitanes/crm/oportunidades_y_pipeline/soldado.py
+++ b/gestion_comercial/sistema_comercial/agents/corps/capitanes/crm/oportunidades_y_pipeline/soldado.py
@@ -1,0 +1,42 @@
+import flet as ft
+from gestion_comercial.sistema_comercial.agent.tools import add_new_lead, update_lead_status_tool
+
+class SoldadoOportunidadesYPipeline:
+    def __init__(self, page: ft.Page):
+        self.page = page
+        print("Soldado de Oportunidades y Pipeline: ¡Listo y dispuesto!")
+
+    def ejecutar_accion(self, accion: str) -> str:
+        """
+        Ejecuta la acción final: llama a las herramientas para gestionar oportunidades.
+        Ej: "command='add', customer_id='some-uuid', source='website', estimated_value=5000"
+        Ej: "command='update', lead_id='another-uuid', new_status='contactado', new_pipeline_stage='negociacion'"
+        """
+        print(f"Soldado: ¡Ejecutando acción de pipeline! - '{accion}'")
+
+        try:
+            parts = accion.split(", ")
+            command = parts[0].split("=")[1].strip("'")
+
+            args = {}
+            for part in parts[1:]:
+                key, value = part.split("=")
+                args[key.strip()] = value.strip("'")
+
+            if command == 'add':
+                # Convertir tipo de dato para el valor
+                if 'estimated_value' in args:
+                    args['estimated_value'] = float(args['estimated_value'])
+                resultado = add_new_lead.invoke(args)
+            elif command == 'update':
+                resultado = update_lead_status_tool.invoke(args)
+            else:
+                resultado = "Error: Comando desconocido para este soldado. Use 'add' o 'update'."
+
+            print(f"Soldado: Herramienta de pipeline ejecutada.")
+            return f"Soldado: ¡Objetivo cumplido! {resultado}"
+
+        except Exception as e:
+            error_message = f"Soldado: Falló la misión. Error al procesar la acción '{accion}'. Detalle: {e}"
+            print(error_message)
+            return error_message

--- a/gestion_comercial/sistema_comercial/agents/corps/capitanes/crm/oportunidades_y_pipeline/teniente.py
+++ b/gestion_comercial/sistema_comercial/agents/corps/capitanes/crm/oportunidades_y_pipeline/teniente.py
@@ -1,17 +1,17 @@
 import flet as ft
-from .sargento import SargentoRegistroPerfil360
+from .sargento import SargentoOportunidadesYPipeline
 
-class TenienteRegistroPerfil360:
+class TenienteOportunidadesYPipeline:
     def __init__(self, page: ft.Page):
         self.page = page
-        self.sargento = SargentoRegistroPerfil360(page=self.page)
-        print("Teniente de Registro y Perfil 360: A la orden.")
+        self.sargento = SargentoOportunidadesYPipeline(page=self.page)
+        print("Teniente de Oportunidades y Pipeline: A la orden.")
 
     def ejecutar_operacion(self, operacion: str) -> str:
         """
         Recibe una operación del capitán y la delega al sargento.
         """
-        print(f"Teniente (Registro y Perfil): Operación recibida - '{operacion}'.")
+        print(f"Teniente (Pipeline): Operación recibida - '{operacion}'.")
         print("Teniente: Pasando tarea al sargento.")
 
         resultado_sargento = self.sargento.ejecutar_tarea(operacion)

--- a/gestion_comercial/sistema_comercial/agents/corps/general_comercial.py
+++ b/gestion_comercial/sistema_comercial/agents/corps/general_comercial.py
@@ -14,7 +14,7 @@ class AgentState(TypedDict):
     messages: Annotated[Sequence[BaseMessage], lambda x, y: x + y]
 
 class GeneralComercial:
-    def __init__(self, page: ft.Page):
+    def __init__(self, page: ft.Page, openai_api_key: str):
         self.page = page
 
         # Instantiate captains
@@ -46,8 +46,7 @@ class GeneralComercial:
         tools = [gestionar_perfil_cliente, gestionar_pipeline_ventas]
 
         # Configure the graph
-        # NOTE: An API key needs to be configured in the environment for this to work.
-        model = ChatOpenAI(temperature=0, streaming=True, model="gpt-4o")
+        model = ChatOpenAI(temperature=0, streaming=True, model="gpt-4o", api_key=openai_api_key)
         model = model.bind_tools(tools)
 
         workflow = StateGraph(AgentState)

--- a/gestion_comercial/sistema_comercial/database.py
+++ b/gestion_comercial/sistema_comercial/database.py
@@ -4,7 +4,8 @@ import os
 import uuid
 import datetime
 import json
-from models.data_models import Customer, Lead, Interaction, SupportTicket
+from typing import List, Dict, Any, Optional
+from gestion_comercial.sistema_comercial.models.data_models import Customer, Lead, Interaction, SupportTicket
 
 # Define the database file path relative to this file
 db_file = "sistema_comercial.db"
@@ -119,6 +120,40 @@ def get_all_customers() -> List[Customer]:
             interests = json.loads(row.interests) if row.interests else []
             customers.append(Customer(**{**row._asdict(), "interests": interests}))
     return customers
+
+# --- CRUD Functions for Leads ---
+
+def add_lead(lead: Lead) -> Lead:
+    with Session() as session:
+        stmt = leads_table.insert().values(
+            id=lead.id,
+            customer_id=lead.customer_id,
+            source=lead.source,
+            status=lead.status,
+            pipeline_stage=lead.pipeline_stage,
+            estimated_value=lead.estimated_value,
+            probability=lead.probability,
+            assigned_agent_id=lead.assigned_agent_id,
+            created_at=lead.created_at
+        )
+        session.execute(stmt)
+        session.commit()
+        return lead
+
+def get_lead_by_id(lead_id: str) -> Optional[Lead]:
+    with Session() as session:
+        stmt = sa.select(leads_table).where(leads_table.c.id == lead_id)
+        result = session.execute(stmt).first()
+        if result:
+            return Lead(**result._asdict())
+        return None
+
+def update_lead_status(lead_id: str, status: str, pipeline_stage: str) -> bool:
+    with Session() as session:
+        stmt = sa.update(leads_table).where(leads_table.c.id == lead_id).values(status=status, pipeline_stage=pipeline_stage)
+        result = session.execute(stmt)
+        session.commit()
+        return result.rowcount > 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This commit implements the first two complete, end-to-end vertical slices for the Commercial Management system, focusing on the CRM subsystem.

Following the user-approved 'Vertical Slice' plan, this change builds the full chain of command for two captains:
1.  `Capitán de Registro y Perfil 360`: For creating and managing customer profiles.
2.  `Capitán de Oportunidades y Pipeline`: For creating and managing sales leads/opportunities.

Key changes:
- Defines a comprehensive database schema and data models for the CRM, including Customers and Leads.
- Implements agent-usable tools for adding/getting customers and adding/updating leads.
- Creates the full tactical team structure (`teniente`, `sargento`, `soldado`) with complete code for both captains.
- Implements the `capitan` files to delegate missions to the tactical teams.
- Updates the `general_comercial.py` agent to recognize and delegate tasks to both captains using LangGraph.
- Adds a comprehensive `.gitignore` file to exclude generated files from version control.